### PR TITLE
showing row names in Data visualization table

### DIFF
--- a/server.R
+++ b/server.R
@@ -358,7 +358,9 @@ shinyServer(function(input, output, session) {
 		}
 		print(M)
 		M
-	})
+	},
+	rownames = TRUE
+	)
 	
 	# *** Print figure legend ***
 	output$FigureLegend <- renderPrint({


### PR DESCRIPTION
The table in the Data visualization tab had the row names hidden by default.